### PR TITLE
Fix stabilizers for groups-with-memory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 This file describes changes in the genss package.
 
+1.6.8 (2022-09-22)
+  - Fix a bug that cold lead to an unexpected error when computing
+    stabilizers in groups-with-memory
+
 1.6.7 (2022-07-31)
   - Minor janitorial changes
 

--- a/gap/genss.gi
+++ b/gap/genss.gi
@@ -141,9 +141,7 @@ InstallGlobalFunction( GENSS_FindVectorsWithShortOrbit,
         Add(l,x);
         Add(data.randpool,x);
     od;
-    if IsObjWithMemory(l[1]) then
-        ForgetMemory(l);
-    fi;
+    ForgetMemory(l);
     c := List(l,x->Set(Factors(CharacteristicPolynomial(x,1):
                                onlydegs := [1..3])));
     v := [];


### PR DESCRIPTION
Computing stabilizers in groups-with-memory could result in unexpected errors where we ended up trying to compute e.g. characteristic polynomials of matrices-with-memory. The problem was this code in `GENSS_FindVectorsWithShortOrbit`:

    if IsObjWithMemory(l[1]) then
        ForgetMemory(l);
    fi;

It can happen that the first element of `l` was a matrix without memory, but later elements *did* have a memory. In that case, we failed to call `ForgetMemory` and thus the problem.

The fix is to simply always invoke `ForgetMemory`.

---

Except... when I tried to add a test case for this, by extracting part of the `recog` example that triggered this bug, I've discovered another problem: a crash in `orb`  🤣 . 

Consider this code:
```
gens:=[ [ [ 0*Z(3), Z(3^2)^2 ], [ Z(3^2)^2, Z(3^2) ] ], [ [ 0*Z(3), Z(3^2) ], [ Z(3^2)^3, Z(3^2)^5 ] ],
  [ [ Z(3^2)^2, Z(3^2)^6 ], [ Z(3^2)^3, Z(3)^0 ] ], [ [ Z(3^2)^3, Z(3^2)^5 ], [ Z(3^2)^3, 0*Z(3) ] ],
  [ [ Z(3^2)^3, Z(3^2)^2 ], [ Z(3^2), Z(3^2)^2 ] ], [ [ Z(3^2)^7, Z(3^2)^3 ], [ Z(3^2)^6, Z(3)^0 ] ],
  [ [ Z(3^2)^7, Z(3^2)^3 ], [ Z(3^2), Z(3^2) ] ], [ [ Z(3^2)^6, Z(3^2)^6 ], [ Z(3), Z(3^2) ] ],
  [ [ Z(3^2)^7, Z(3) ], [ Z(3), 0*Z(3) ] ], [ [ Z(3), Z(3^2)^2 ], [ 0*Z(3), Z(3) ] ],
  [ [ Z(3^2)^7, Z(3^2)^5 ], [ Z(3^2)^2, Z(3^2)^3 ] ], [ [ Z(3^2)^2, Z(3^2) ], [ Z(3^2)^3, Z(3^2)^6 ] ],
  [ [ Z(3^2)^2, Z(3^2) ], [ Z(3^2)^7, 0*Z(3) ] ], [ [ Z(3), Z(3^2)^5 ], [ 0*Z(3), Z(3)^0 ] ],
  [ [ Z(3^2), Z(3^2)^5 ], [ Z(3^2)^5, Z(3^2)^6 ] ], [ [ Z(3^2)^2, Z(3)^0 ], [ Z(3^2)^6, Z(3^2) ] ],
  [ [ Z(3^2)^3, Z(3^2) ], [ Z(3^2), Z(3) ] ], [ [ Z(3^2)^3, 0*Z(3) ], [ Z(3^2)^3, Z(3^2) ] ],
  [ [ Z(3^2)^2, 0*Z(3) ], [ Z(3^2)^3, Z(3^2)^6 ] ], [ [ Z(3^2)^3, Z(3^2)^5 ], [ Z(3^2)^6, Z(3^2)^2 ] ],
  [ [ Z(3^2)^5, Z(3^2)^5 ], [ Z(3^2)^3, 0*Z(3) ] ], [ [ Z(3^2)^2, Z(3^2)^5 ], [ Z(3^2)^7, 0*Z(3) ] ],
  [ [ Z(3^2)^5, Z(3)^0 ], [ 0*Z(3), Z(3^2)^3 ] ], [ [ Z(3^2)^5, Z(3^2)^6 ], [ Z(3^2)^5, Z(3^2) ] ],
  [ [ Z(3^2)^7, Z(3)^0 ], [ Z(3^2), Z(3^2)^3 ] ], [ [ Z(3^2)^5, Z(3^2)^7 ], [ Z(3^2)^7, Z(3)^0 ] ],
  [ [ Z(3^2)^6, 0*Z(3) ], [ Z(3^2)^3, Z(3^2)^2 ] ], [ [ Z(3^2)^6, 0*Z(3) ], [ Z(3^2)^7, Z(3^2)^2 ] ],
  [ [ Z(3^2)^6, Z(3) ], [ Z(3^2)^3, Z(3^2)^3 ] ], [ [ Z(3)^0, Z(3)^0 ], [ Z(3^2)^6, Z(3^2)^5 ] ],
  [ [ Z(3^2)^7, Z(3^2)^7 ], [ Z(3), Z(3^2)^6 ] ], [ [ Z(3^2)^6, Z(3^2)^6 ], [ Z(3^2)^5, Z(3)^0 ] ],
  [ [ Z(3^2)^7, Z(3^2) ], [ Z(3^2)^2, Z(3^2)^7 ] ], [ [ Z(3^2)^7, Z(3^2)^6 ], [ Z(3)^0, Z(3^2)^6 ] ],
  [ [ Z(3^2)^2, Z(3^2) ], [ Z(3^2)^5, Z(3^2) ] ], [ [ Z(3^2)^7, Z(3^2)^6 ], [ Z(3^2)^6, 0*Z(3) ] ] ];

gm := GroupWithMemory(gens);

Reset(GlobalRandomSource, 30);;
Reset(GlobalMersenneTwister, 30);;
S := StabilizerChain(gm,rec( Projective := false,
        Cand := rec( points := One(gens[1]), ops := [OnLines,OnLines] ) ) );
```

Running it leads to a segfault, here's the last few lines of the backtrace:
```
0   orb.so                        	       0x103827b48 ELM_PLIST + 4 (plist.h:203) [inlined]
1   orb.so                        	       0x103827b48 HTAdd_TreeHash_C + 328 (orb.c:1152)
2   orb.so                        	       0x103827b40 HTAdd_TreeHash_C + 320 (orb.c:1151)
3   gap                           	       0x10271a9e4 CALL_3ARGS + 28 (calls.h:321) [inlined]
```

I don't have time to debug it right now, so I am documenting it here to not forget about it.