### PR TITLE
Turn IO into an optional dependency

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -118,10 +118,11 @@ Dependencies := rec(
   GAP := ">=4.9",
   NeededOtherPackages := [
     ["GAPDoc", ">= 1.5"],
-    ["IO", ">= 4.2"],
     ["orb", ">= 4.5"],
   ],
-  SuggestedOtherPackages := [],
+  SuggestedOtherPackages := [
+    ["IO", ">= 4.2"],
+  ],
   ExternalConditions := []
 ),
 


### PR DESCRIPTION
The code to support this was added in 2007, let's make use of it.

So this was much simpler than I thought... because it was already implemented.

Resolves #18

CC @ThomasBreuer